### PR TITLE
Added missing parameter smbworkgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,22 @@ This will install the authconfig package if necessary and set `ldap`, `ldapauth`
 
 ```puppet
 class { 'authconfig' :
-  ldap        => true,
-  ldapauth    => true,
-  ldaptls     => false,
-  ldapserver  => '192.168.42.42',
-  ldapbasedn  => 'dc=example,dc=com',
-  krb5        => true,
-  krb5realm   => 'example.com',
-  krb5kdc     => ['kdc1.example.com', 'kdc2.example.com'],
-  krb5kadmin  => 'kadmin.example.com',
-  cache       => true,
-  winbind     => false,
-  winbindauth => false,
-  smbsecurity => 'ads',
-  smbrealm    => 'example.com',
-  winbindjoin => 'user@domain%password',
+  ldap         => true,
+  ldapauth     => true,
+  ldaptls      => false,
+  ldapserver   => '192.168.42.42',
+  ldapbasedn   => 'dc=example,dc=com',
+  krb5         => true,
+  krb5realm    => 'example.com',
+  krb5kdc      => ['kdc1.example.com', 'kdc2.example.com'],
+  krb5kadmin   => 'kadmin.example.com',
+  cache        => true,
+  winbind      => false,
+  winbindauth  => false,
+  smbsecurity  => 'ads',
+  smbrealm     => 'example.com',
+  smbworkgroup => 'MYGROUP',
+  winbindjoin  => 'user@domain%password',
 }
 ```
 
@@ -96,6 +97,10 @@ The style of Winbind connection. Default: `ads`
 #### `smbrealm`
 
 Specify Active Directory realm
+
+#### `smbworkgroup`
+
+Specify Active Directory workgroup
 
 #### `smbservers`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -164,6 +164,11 @@ class authconfig (
           fail('The smbrealm parameter is required when winbind is set to true')
         }
 
+        #smbworkgroup= Active directory workgroup (e.g. MYGROUP)
+        if $smbworkgroup == undef {
+          fail('The smbworkgroup parameter is required when winbind is set to true')
+        }
+
         #winbindjoin= User name of domain admin user to authenticate the domain join of the machine.
         if $winbindjoin == undef {
           fail('The winbindjoin parameter is required when winbind is set to true')
@@ -192,6 +197,10 @@ class authconfig (
         $smbrealm_val = "--smbrealm=${smbrealm}"
       }
 
+      if ($smbworkgroup) {
+        $smbworkgroup_val = "--smbworkgroup=${smbworkgroup}"
+      }
+
       if ($winbindjoin) {
         $winbindjoin_val = "--winbindjoin=${winbindjoin}"
       }
@@ -199,6 +208,8 @@ class authconfig (
       if (is_array($smbservers)) {
         $smbservers_joined = join($smbservers, ',')
         $smbservers_val = "--smbservers=${smbservers_joined}"
+      } else {
+        $smbservers_val = "--smbservers=${smbservers}"
       }
 
 
@@ -230,7 +241,7 @@ class authconfig (
       }
 
       $winbind_flags = $winbind ? {
-        true    => "${winbind_flg} ${winbindauth_flg} ${smbsecurity_val} ${smbrealm_val} ${winbindjoin_val} ${smbservers_val}",
+        true    => "${winbind_flg} ${winbindauth_flg} ${smbsecurity_val} ${smbrealm_val} ${smbworkgroup_val} ${winbindjoin_val} ${smbservers_val}",
         default => '',
       }
 

--- a/spec/classes/authconfig_spec.rb
+++ b/spec/classes/authconfig_spec.rb
@@ -68,11 +68,12 @@ describe 'authconfig' do
     context 'Winbind enabled' do
       before :each do
         params.merge!(
-          :winbind     => true,
-          :winbindauth => true,
-          :smbsecurity => 'ads',
-          :smbrealm    => 'example.com',
-          :winbindjoin => 'user@domain%password',
+          :winbind      => true,
+          :winbindauth  => true,
+          :smbsecurity  => 'ads',
+          :smbrealm     => 'example.com',
+          :smbworkgroup => 'MYGROUP',
+          :winbindjoin  => 'user@domain%password',
         )
       end
     end


### PR DESCRIPTION
Added missing parameter `smbworkgroup` which is required in most Active Directory environments.

Also fixed syntax of `smbservers` so it works if you only pass a variable instead of an array.
