### PR TITLE
Adding /usr/bin to exec path so /usr/sbin/cacertdir_rehash works

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -323,7 +323,7 @@ class authconfig (
         hasrestart => true,
       } ->
       exec {'authconfig command':
-        path    => '/usr/sbin',
+        path    => ['/usr/bin', '/usr/sbin'],
         command => $authconfig_update_cmd,
         unless  => $exec_check_cmd
       }


### PR DESCRIPTION
On RHEL 7, authconfig attempts to run /usr/sbin/cacertdir_rehash, which assumes that /usr/bin is in the path. If /usr/bin isn't in the path, the cacertdir_rehash fails silently, which causes the certs not to be rehashed.

This change has been tested on RHEL 6 and RHEL 7 with no ill effects.
