### PR TITLE
* forcelegacy parameter is unknown on RHEL/CentOS <= 5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,9 +100,20 @@ class authconfig (
         default => '--disablesssdauth',
       }
 
-      $forcelegacy_flg = $forcelegacy ? {
-        true    => '--enableforcelegacy',
-        default => '--disableforcelegacy',
+      case $operatingsystem {
+        'RedHat', 'CentOS': {
+          if $operatingsystemmajrelease >= 6 {
+            $forcelegacy_flg = $forcelegacy ? {
+              true    => '--enableforcelegacy',
+              default => '--disableforcelegacy',
+            }
+          } else {
+		    $forcelegacy_flg = ''
+		  }
+        }
+        default: {
+          $forcelegacy_flg = ''
+        }
       }
 
       # NIS

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,20 +100,17 @@ class authconfig (
         default => '--disablesssdauth',
       }
 
-      case $operatingsystem {
-        'RedHat', 'CentOS': {
-          if $operatingsystemmajrelease >= 6 {
-            $forcelegacy_flg = $forcelegacy ? {
-              true    => '--enableforcelegacy',
-              default => '--disableforcelegacy',
-            }
-          } else {
-		    $forcelegacy_flg = ''
-		  }
-        }
-        default: {
+      if $::osfamily == 'RedHat' {
+        if $::operatingsystemmajrelease >= 6 {
+          $forcelegacy_flg = $forcelegacy ? {
+            true    => '--enableforcelegacy',
+            default => '--disableforcelegacy',
+          }
+        } else {
           $forcelegacy_flg = ''
         }
+      } else {
+        $forcelegacy_flg = ''
       }
 
       # NIS


### PR DESCRIPTION
Hi!

RHEL/CentOS <= 5 do not understand that parameter, therefore we need to check this in the code. I'm not really a "Rubyist" - there might be a more elegant way to achieve this.