### PR TITLE
Clean up mkhomedir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -275,9 +275,14 @@ class authconfig (
         default => '--disablefingerprint',
       }
 
-      $mkhomedir_flg = $mkhomedir ? {
-        true    => '--enablemkhomedir',
-        default => '--disablemkhomedir',
+      case $::operatingsystemmajrelease {
+        '5':     { $mkhomedir_flg = '' } # not available on EL5
+        default: {
+          $mkhomedir_flg = $mkhomedir ? {
+            true    => '--enablemkhomedir',
+            default => '--disablemkhomedir',
+          }
+        }
       }
 
       #Add PAM Access
@@ -344,6 +349,13 @@ class authconfig (
           hasrestart => true,
           before     => Exec['authconfig command'],
         }
+      }
+
+      if ($mkhomedir) {
+        package { $authconfig::params::mkhomedir_packages:
+          ensure => installed,
+        }
+      # service oddjobd is started automatically by authconfig
       }
 
       package { $authconfig::params::packages:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,17 +1,18 @@
 # authconfig::params
 class authconfig::params () {
 
-  $packages = ['authconfig']
-  $cache_packages = ['nscd']
-  $ldap_packages  = $::operatingsystemmajrelease ? {
-    7 => ['openldap-clients', 'nss-pam-ldapd'],
+  $packages           = ['authconfig']
+  $cache_packages     = ['nscd']
+  $ldap_packages      = $::operatingsystemmajrelease ? {
+    7       => ['openldap-clients', 'nss-pam-ldapd'],
     default => ['openldap-clients', 'nss-pam-ldapd', 'pam_ldap']
   }
-  $krb5_packages  = ['pam_krb5', 'krb5-workstation']
-  $nis_packages   = ['ypbind']
-  $nis_services   = ['ypbind']
-  $services       = []
-  $cache_services = ['nscd']
-  $ldap_services  = ['nslcd']
+  $krb5_packages      = ['pam_krb5', 'krb5-workstation']
+  $mkhomedir_packages = ['oddjob-mkhomedir']
+  $nis_packages       = ['ypbind']
+  $nis_services       = ['ypbind']
+  $services           = []
+  $cache_services     = ['nscd']
+  $ldap_services      = ['nslcd']
 
 }


### PR DESCRIPTION
This PR adds package installation for mkhomedir and makes sure authconfig doesn't add the mkhomedir_flg to the authconfig exec on EL5 where it isn't supported.

Params.pp is more neatly alligned.