### PR TITLE
Fix on RHEL 5

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,10 @@ class authconfig::params () {
     default => ['openldap-clients', 'nss-pam-ldapd', 'pam_ldap']
   }
   $krb5_packages      = ['pam_krb5', 'krb5-workstation']
-  $mkhomedir_packages = ['oddjob-mkhomedir']
+  $mkhomedir_packages = $::operatingsystemmajrelease ? {
+    5       => ['pam'],
+    default => ['oddjob-mkhomedir']
+  }
   $nis_packages       = ['ypbind']
   $nis_services       = ['ypbind']
   $services           = []


### PR DESCRIPTION
Don't try to install oddjob-mkhomedir on RHEL 5 since it's not available there. 'pam' package is all that is needed to successfully enable mkhomedir.