### PR TITLE
Fix Puppet 4 parsing error during version comp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -206,7 +206,7 @@ class authconfig (
       }
 
       if $::osfamily == 'RedHat' {
-        if $::operatingsystemmajrelease >= 6 {
+        if versioncmp($::operatingsystemmajrelease, '6') >= 0 {
           $forcelegacy_flg = $forcelegacy ? {
             true    => '--enableforcelegacy',
             default => '--disableforcelegacy',


### PR DESCRIPTION
If one tries to run the module as such today with Puppet 4 parse will
complaint about comparing String with Integer. To fix that we rely on
`versioncmp()` to effectively ensure the version comparison.

Fix: #19 