### PR TITLE
Improve NIS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ NIS Domain
 
 #### `nisserver`
 
-NIS Server
+NIS Server - NIS server hostname, leaving this undef will choose NIS broadcast mode
 
 #### `shadow`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -457,6 +457,19 @@ class authconfig (
         }
       }
 
+      if $nis {
+        package { $authconfig::params::nis_packages:
+          ensure => installed,
+        } ->
+        service { $authconfig::params::nis_services:
+          ensure     => running,
+          enable     => true,
+          hasstatus  => true,
+          hasrestart => true,
+          before     => Exec['authconfig command'],
+        }
+      }
+
       if $mkhomedir {
         package { $authconfig::params::mkhomedir_packages:
           ensure => installed,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@
 #    NIS Domain
 #
 #  [*nisserver*]
-#    NIS Server
+#    NIS Server (optional, leave undefined to choose broadcast mode)
 #
 #  [*shadow*]
 #    Enable shadow password
@@ -223,10 +223,6 @@ class authconfig (
 
         if !$nisdomain {
           fail('The nisdomain parameter is required when nis set to true')
-        }
-
-        if !$nisserver {
-          fail('The nisserver parameter is required when nis is set to true')
         }
 
       }


### PR DESCRIPTION
Improve the NIS support to add support for:
* NIS broadcast mode (automatically discover the server)
* Automatically install and start the ypbind service (needed for NIS to work)