### PR TITLE
Quote ldap server to prevent command error

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,7 +192,7 @@ class authconfig (
       }
 
       if $ldapserver {
-        $ldapserver_val = "--ldapserver=${ldapserver}"
+        $ldapserver_val = "--ldapserver='${ldapserver}'"
       }
 
       $sssd_flg = $sssd ? {


### PR DESCRIPTION
We're using multiple ldap servers 'ldap://ldap1.server.tld/ ldap://ldap2.server.tld/', to prevent authconfig failing, you need to quote the string.
