### PR TITLE
Squash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,7 +192,8 @@ class authconfig (
       }
 
       if $ldapserver {
-        $ldapserver_val = "--ldapserver='${ldapserver}'"
+        $ldapserver_real = join(any2array($ldapserver), ',')
+        $ldapserver_val = "--ldapserver=${ldapserver_real}"
       }
 
       $sssd_flg = $sssd ? {
@@ -293,7 +294,8 @@ class authconfig (
       }
 
       if $krb5kadmin {
-        $krb5kadmin_val = "--krb5adminserver=${krb5kadmin}"
+        $krb5kadmin_real = join(any2array($krb5kadmin), ',')
+        $krb5kadmin_val = "--krb5adminserver=${krb5kadmin_real}"
       }
 
       # Winbind

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class authconfig::params () {
   $packages           = ['authconfig']
   $cache_packages     = ['nscd']
   $ldap_packages      = $::operatingsystemmajrelease ? {
-    5       => ['openldap-clients', 'nss-ldap'],
+    5       => ['openldap-clients', 'nss_ldap-253'],
     7       => ['openldap-clients', 'nss-pam-ldapd'],
     default => ['openldap-clients', 'nss-pam-ldapd', 'pam_ldap']
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,11 @@ class authconfig::params () {
   $nis_services       = ['ypbind']
   $services           = []
   $cache_services     = ['nscd']
-  $ldap_services      = ['nslcd']
+
+  # RHEL 5 Doesn't have nslcd package available.
+  $ldap_services      = $::operatingsystemmajrelease ? {
+    5       => [],
+    default => ['nslcd'],
+  }   
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class authconfig::params () {
   $packages           = ['authconfig']
   $cache_packages     = ['nscd']
   $ldap_packages      = $::operatingsystemmajrelease ? {
+    5       => ['openldap-clients', 'nss-ldap'],
     7       => ['openldap-clients', 'nss-pam-ldapd'],
     default => ['openldap-clients', 'nss-pam-ldapd', 'pam_ldap']
   }


### PR DESCRIPTION
Added the ability for ldapserver and/or krb5kadmin to be arrays.
Added condition for RHEL5.  RHEL5 doesn't have 'nss-pam-ldapd' or 'pam_ldap' RPM packages available.
Update params.pp
Added checks for RHEL5.  Package 'nscd' isn't available on RHEL5.
Mistakenly modified '' instead of ''.  Fixing that.