### PR TITLE
Added RHEL5 condition and appropriate modifications for RHEL5 support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,7 +192,8 @@ class authconfig (
       }
 
       if $ldapserver {
-        $ldapserver_val = "--ldapserver='${ldapserver}'"
+        $ldapserver_real = join(any2array($ldapserver), ',')
+        $ldapserver_val = "--ldapserver=${ldapserver_real}"
       }
 
       $sssd_flg = $sssd ? {
@@ -293,7 +294,8 @@ class authconfig (
       }
 
       if $krb5kadmin {
-        $krb5kadmin_val = "--krb5adminserver=${krb5kadmin}"
+        $krb5kadmin_real = join(any2array($krb5kadmin), ',')
+        $krb5kadmin_val = "--krb5adminserver=${krb5kadmin_real}"
       }
 
       # Winbind

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class authconfig::params () {
   $packages           = ['authconfig']
   $cache_packages     = ['nscd']
   $ldap_packages      = $::operatingsystemmajrelease ? {
+    5       => ['openldap-clients', 'nss_ldap-253'],
     7       => ['openldap-clients', 'nss-pam-ldapd'],
     default => ['openldap-clients', 'nss-pam-ldapd', 'pam_ldap']
   }
@@ -16,6 +17,11 @@ class authconfig::params () {
   $nis_services       = ['ypbind']
   $services           = []
   $cache_services     = ['nscd']
-  $ldap_services      = ['nslcd']
+
+  # RHEL 5 Doesn't have nslcd package available.
+  $ldap_services      = $::operatingsystemmajrelease ? {
+    5       => [],
+    default => ['nslcd'],
+  }   
 
 }


### PR DESCRIPTION
Added condition for RHEL5.  RHEL5 doesn't have 'nss-pam-ldapd' or 'pam_ldap' RPM packages available.

According to:  https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Deployment_Guide/s1-ldap-pam.html, only openldap, openldap-clients and nss_ldap are required for LDAP authentication.

Install the Necessary LDAP Packages.
First, make sure that the appropriate packages are installed on both the LDAP server and the LDAP client machines. The LDAP server needs the openldap-servers package.
The openldap, openldap-clients, and nss_ldap packages need to be installed on all LDAP client machines.

Update params.pp

Added checks for RHEL5.  Package 'nscd' isn't available on RHEL5.

Mistakenly modified '' instead of ''.  Fixing that.
