### PR TITLE
Fix the versioncmp issue that is causing travis builds to fail

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,7 +221,10 @@ class authconfig (
       }
 
       if $::osfamily == 'RedHat' {
-        if versioncmp($::operatingsystemmajrelease, '6') >= 0 {
+# put $::operatingsystemmajrelease in quotes to force it to a string.
+# to make lint happy, the string has to have more than just the bare variable. :P
+# so compare ${::operatingsystemmajrelease}.0 against 6.0
+        if versioncmp("${::operatingsystemmajrelease}.0", '6.0') >= 0 {
           $forcelegacy_flg = $forcelegacy ? {
             true    => '--enableforcelegacy',
             default => '--disableforcelegacy',


### PR DESCRIPTION
Travis CI builds were failing due to some versions of puppet returning an integer for `$::operatingsystemmajrelease` and thus failing in the `versioncmp` code.

To fix this, I put `$::operatingsystemmajrelease` in a string; since lint doesn't like a string with just the bare variable, I added `.0` to the os version and the comparison version `6.0`.