### PR TITLE
Fix unknown variable build errors

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,6 +204,8 @@ class authconfig (
 
       if $ldaploadcacert {
         $ldaploadcacert_val = "--ldaploadcacert='${ldaploadcacert}'"
+      } else {
+        $ldaploadcacert_val = ''
       }
 
       if $ldapserver {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,7 +221,10 @@ class authconfig (
       }
 
       if $::osfamily == 'RedHat' {
-        if versioncmp($::operatingsystemmajrelease, '6') >= 0 {
+# put $::operatingsystemmajrelease in quotes to force it to a string.
+# to make lint happy, the string has to have more than just the bare variable. :P
+# so compare ${::operatingsystemmajrelease}.0 against 6.0
+        if versioncmp("${::operatingsystemmajrelease}.0", '6.0') >= 0 {
           $forcelegacy_flg = $forcelegacy ? {
             true    => '--enableforcelegacy',
             default => '--disableforcelegacy',


### PR DESCRIPTION
This makes the "Allowed Failures" part of Travis not fail, by defining `$ldaploadcacert_val` as an empty string when the caller did not pass an `$ldaploadcacert` value.

(it also incorporates the commit from PR #34 so that travis works at all)