### PR TITLE
Improve sssd configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Whether to use naming services caches
 
 Whether to automatically create user home dir on first login
 
+#### `rfc2307bis`
+
+Boolean to determine if the LDAP schema uses rfc2307 (false) or rfc2307bis (true).
+Only valid if `sssd` is true.
+If this value is `true` on a system that does not support rfc2307bis (RHEL < 6), a catalog error will be generated.
+
 ## License
 
 Apache License v2

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,6 +204,8 @@ class authconfig (
 
       if $ldaploadcacert {
         $ldaploadcacert_val = "--ldaploadcacert='${ldaploadcacert}'"
+      } else {
+        $ldaploadcacert_val = ''
       }
 
       if $ldapserver {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,7 +221,10 @@ class authconfig (
       }
 
       if $::osfamily == 'RedHat' {
-        if versioncmp($::operatingsystemmajrelease, '6') >= 0 {
+# put $::operatingsystemmajrelease in quotes to force it to a string.
+# to make lint happy, the string has to have more than just the bare variable. :P
+# so compare ${::operatingsystemmajrelease}.0 against 6.0
+        if versioncmp("${::operatingsystemmajrelease}.0", '6.0') >= 0 {
           $forcelegacy_flg = $forcelegacy ? {
             true    => '--enableforcelegacy',
             default => '--disableforcelegacy',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,9 @@ class authconfig::params () {
 
   $packages           = ['authconfig']
   $cache_packages     = ['nscd']
+  $sssd_packages      = $::operatingsystemmajrelease ? {
+    default => ['sssd', 'sssd-client']
+  }
   $ldap_packages      = $::operatingsystemmajrelease ? {
     7       => ['openldap-clients', 'nss-pam-ldapd'],
     default => ['openldap-clients', 'nss-pam-ldapd', 'pam_ldap']
@@ -17,7 +20,10 @@ class authconfig::params () {
   $services           = []
   $cache_services     = ['nscd']
   $ldap_services      = ['nslcd']
+  $sssd_services      = ['sssd']
 
   $smartcard_packages = [ 'nss-tools', 'nss-pam-ldapd', 'esc', 'pam_pkcs11', 'pam_krb5', 'coolkey', 'pcsc-lite-ccid', 'pcsc-lite', 'pcsc-lite-libs' ]
+
+  $enablerfc2307bis_allowed = (versioncmp("${::operatingsystemmajrelease}.0", '6.0') >= 0)
 
 }


### PR DESCRIPTION
* add ability to configure the `rfc2307bis` sssd option
* if sssd enabled, install sssd packages if necessary
* if sssd enabled, ensure sssd services are running *after* authconfig runs
* if sssd enabled, do not install ldap packages or start ldap services

Note - this PR incorporates the commits from PR #34 (Fix the versioncmp issue that is causing travis builds to fail) and PR #35 (Fix unknown variable build errors)