### PR TITLE
Update to match stdlib <7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,6 +46,6 @@
   ],
   "description": "A Puppet module that lets one manage its system authconfig settings.",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.3.2 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.3.2 < 7.0.0"}
   ]
 }


### PR DESCRIPTION
I see no reason to hold stdlib back to below version 5 for this module. It works well with version 6.